### PR TITLE
maudfiles

### DIFF
--- a/lib/maud.js
+++ b/lib/maud.js
@@ -1,0 +1,20 @@
+const m = require('./maudite')
+const path = require('path')
+const fs = require('fs')
+
+function maudRequire (filename) {
+  // TODO cache
+  const filePath = path.resolve(filename)
+  const fileData = fs.readFileSync(filename, 'utf8')
+
+  const wrapped = new Function('m', 'p', 'return m`' + fileData + '`') // eslint-disable-line no-new-func
+
+  function p (...args) {
+    const partialPath = String.raw(...args)
+    const templ = maudRequire(path.join(path.dirname(filePath), partialPath + '.maud'))
+    return context => templ.asString(context)
+  }
+  return wrapped(m, p)
+}
+
+module.exports = maudRequire

--- a/test/fixtures/partial.maud
+++ b/test/fixtures/partial.maud
@@ -1,0 +1,1 @@
+This is a partial.

--- a/test/fixtures/template.maud
+++ b/test/fixtures/template.maud
@@ -1,0 +1,4 @@
+
+Hello, ${'world'}!
+
+${p`partial`}

--- a/test/maud.js
+++ b/test/maud.js
@@ -1,0 +1,14 @@
+const maud = require('../lib/maud')
+const path = require('path')
+const assert = require('assert')
+const templ = maud(path.join(__dirname, 'fixtures', 'template.maud'))
+
+test`maud files work`(_ => {
+  const result = templ.asString({world: 'World'})
+  assert.equal(`
+Hello, World!
+
+This is a partial.
+
+`, result)
+})


### PR DESCRIPTION
Alright here's the start of something neat. Here's an addition that allows you to load `*.maud` files. Basically these are maudite templates with an implicit wrapping of the file contents, and an additional function `p` which allows you to load partials as templates on their own.

For the moment, there's no really good way of making partials inline. The best you can do right now is inline calls to `m`, which is problematic since those aren't cached in any way. Templates loaded with the `p` function will (eventually) be cached, so for now that's the safest approach.

Yeah this uses the function constructor. I'm not sure of a non-`eval` way of leveraging V8 to do the parsing. I guess maybe `require('vm')`, but this is just a quick-n-dirty version to see if it can work... and it does.

@davglass PTAL.

TODO:
- [ ] Caching.
- [ ] Figure out inline partials. Or decide not to.
- [ ] Polish.
- [ ] Docs.
